### PR TITLE
Fix duplicated preset handlers in App.svelte

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -93,29 +93,6 @@
     }
   }
 
-  function setPreset(preset: string) {
-    if (!config) return;
-    const presetData = resolutionPresets[preset];
-    config.region_preset = preset;
-    if (presetData) {
-      config.red_region = { ...presetData.red_region };
-      config.yellow_region = { ...presetData.yellow_region };
-      config.hunger_region = { ...presetData.hunger_region };
-    }
-  }
-
-  function handlePresetChange(event: Event) {
-    const target = event.target as HTMLSelectElement;
-    setPreset(target.value);
-  }
-
-  $: if (config) {
-    const derivedTimeout = calculateMaxBiteTimeMs(config.rod_lure_value);
-    if (config.max_fishing_timeout_ms !== derivedTimeout) {
-      config.max_fishing_timeout_ms = derivedTimeout;
-    }
-  }
-
   onMount(() => {
     loadState();
 


### PR DESCRIPTION
## Summary
- remove duplicate preset handler functions that caused build-time redeclaration errors
- retain single reactive timeout update tied to lure value

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415abf9dbc83258aad7947b4eadf7b)