### PR TITLE
Fix duplicated preset handlers and stabilize session controls

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -17,6 +17,7 @@
   let refreshInterval: ReturnType<typeof setInterval> | null = null;
   const settingsTabs = ['general', 'automation', 'regions'] as const;
   let activeSettingsTab: (typeof settingsTabs)[number] = 'general';
+  let configDirty = false;
 
   const resolutionPresets: Record<string, { red_region: { x: number; y: number; width: number; height: number }; yellow_region: { x: number; y: number; width: number; height: number }; hunger_region: { x: number; y: number; width: number; height: number } }> = {
     '3440x1440': {
@@ -44,9 +45,18 @@
     : 'border-amber-500/40 bg-amber-500/10 text-amber-100';
   $: statusDotClass = sessionRunning ? 'bg-emerald-400' : 'bg-amber-400';
 
-  async function loadState() {
+  function markConfigDirty() {
+    configDirty = true;
+  }
+
+  async function loadState(options: { preserveConfig?: boolean } = {}) {
+    const { preserveConfig = false } = options;
     const state = await getState();
-    config = state.config;
+    if (!preserveConfig || !configDirty || !config) {
+      config = state.config;
+      configDirty = false;
+    }
+
     stats = state.stats;
     session = state.session;
     status = statusText;
@@ -55,42 +65,20 @@
   async function start() {
     await startBot();
     status = 'Fishing cycle engaged';
-    await loadState();
+    await loadState({ preserveConfig: true });
   }
 
   async function stop() {
     await stopBot();
     status = 'Ritual paused';
-    await loadState();
+    await loadState({ preserveConfig: true });
   }
 
   async function saveConfig() {
     if (!config) return;
     await persistConfig(config);
     status = 'Configuration saved';
-  }
-
-  function setPreset(preset: string) {
-    if (!config) return;
-    const presetData = resolutionPresets[preset];
-    config.region_preset = preset;
-    if (presetData) {
-      config.red_region = { ...presetData.red_region };
-      config.yellow_region = { ...presetData.yellow_region };
-      config.hunger_region = { ...presetData.hunger_region };
-    }
-  }
-
-  function handlePresetChange(event: Event) {
-    const target = event.target as HTMLSelectElement;
-    setPreset(target.value);
-  }
-
-  $: if (config) {
-    const derivedTimeout = calculateMaxBiteTimeMs(config.rod_lure_value);
-    if (config.max_fishing_timeout_ms !== derivedTimeout) {
-      config.max_fishing_timeout_ms = derivedTimeout;
-    }
+    configDirty = false;
   }
 
   function setPreset(preset: string) {
@@ -120,7 +108,7 @@
     loadState();
 
     refreshInterval = setInterval(() => {
-      loadState();
+      loadState({ preserveConfig: true });
     }, 1000);
   });
 
@@ -304,7 +292,7 @@
       </div>
 
       {#if config}
-        <div class="space-y-4">
+        <div class="space-y-4" on:input={markConfigDirty} on:change={markConfigDirty}>
           <div class="flex flex-wrap gap-2 border border-white/10 bg-[#0f0f0f] p-2 rounded-none text-sm">
             {#each settingsTabs as tab}
               <button

--- a/src/lib/ipc.ts
+++ b/src/lib/ipc.ts
@@ -102,31 +102,55 @@ function fallbackState(): BotState {
 }
 
 const api: BotApi | undefined = typeof window !== 'undefined' ? window.bot : undefined;
+let inMemoryState: BotState | null = null;
+
+function ensureFallbackState(): BotState {
+  if (!inMemoryState) {
+    inMemoryState = fallbackState();
+  }
+  return inMemoryState;
+}
 
 export async function getState(): Promise<BotState> {
   if (api?.getState) return api.getState();
-  return fallbackState();
+  return ensureFallbackState();
 }
 
 export async function getConfig(): Promise<BotConfig> {
   if (api?.getConfig) return api.getConfig();
-  return fallbackState().config;
+  return ensureFallbackState().config;
 }
 
 export async function getStats(): Promise<{ stats: LifetimeStats; session: SessionState }> {
   if (api?.getStats) return api.getStats();
-  const fallback = fallbackState();
+  const fallback = ensureFallbackState();
   return { stats: fallback.stats, session: fallback.session };
 }
 
 export async function saveConfig(config: BotConfig): Promise<void> {
   if (api?.saveConfig) return api.saveConfig(config);
+
+  const state = ensureFallbackState();
+  state.config = config;
+  state.session.last_action = 'Config updated';
 }
 
 export async function startSession(): Promise<void> {
   if (api?.startSession) return api.startSession();
+
+  const state = ensureFallbackState();
+  state.session.running = true;
+  state.session.started_at = Date.now();
+  state.session.last_action = 'Session started';
 }
 
 export async function stopSession(): Promise<void> {
   if (api?.stopSession) return api.stopSession();
+
+  const state = ensureFallbackState();
+  state.session.running = false;
+  state.session.started_at = null;
+  state.session.last_action = 'Session stopped';
+  state.stats.sessions_completed += 1;
+  state.stats.last_updated = new Date().toISOString();
 }


### PR DESCRIPTION
## Summary
- remove duplicate preset handler functions that caused build-time redeclaration errors
- retain single reactive timeout update tied to lure value
- keep config edits intact during periodic refreshes and support offline fallback state
- enable start/stop buttons to toggle session state even when the Electron IPC bridge is unavailable

## Testing
- npm run build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415abf9dbc83258aad7947b4eadf7b)