### PR TITLE
Threaded backend fishing loop with screen-capture detection and mouse input

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -12,6 +12,9 @@ parking_lot = "0.12"
 chrono = { version = "0.4", features = ["serde"] }
 once_cell = "1"
 tauri = { version = "1.5", features = ["dialog-all", "shell-open", "window-all"] }
+image = "0.24"
+screenshots = "0.8"
+enigo = "0.2.1"
 
 [build-dependencies]
 tauri-build = { version = "1.5", features = [] }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -25,8 +25,8 @@ fn get_stats(state: State<'_, AppState>) -> (LifetimeStats, SessionState) {
 }
 
 #[tauri::command]
-fn start_session(state: State<'_, AppState>) {
-    start_bot(&state.0);
+fn start_session(window: tauri::Window, state: State<'_, AppState>) {
+    start_bot(&state.0, window);
 }
 
 #[tauri::command]


### PR DESCRIPTION
### Motivation
- Move the main fishing loop into the backend worker so the UI remains responsive and the loop can be stopped safely.
- Replace console logging with IPC so the frontend receives realtime updates via the `state-update` Tauri event.
- Restore detection by using screen-capture + pixel color counting (red bite / yellow caught) and perform input actions for casting/reeling.
- Ensure thread-safe reads of `SharedState` and stop control via an atomic running flag.

### Description
- Added an atomic `running: Arc<AtomicBool>` to `SharedState` and initialize it in `SharedState::new()`.
- Reworked `start_bot` to accept a `tauri::Window`, set the atomic running flag, and spawn the fishing loop in a background thread using `std::thread::spawn`.
- Implemented screen-capture based detection: added `capture_region`, `count_matching_pixels`, and a small `Color` helper; detection uses `image` + `screenshots` to sample `red_region` and `yellow_region` and sets `bite_detected` / `fish_caught` accordingly.
- Integrated mouse input using `enigo` to perform a left-click when casting and spam-click during reeling.
- Emit session updates to the UI by replacing `println!` with `window.emit("state-update", &session_snapshot)` via `emit_session_update` helper.
- Read configuration values with `state.config.read()` at the start of each loop iteration (then drop the lock) and use `while state.running.load(Ordering::Relaxed)` as the loop condition so `Stop` immediately terminates the thread.
- Updated API and dependencies: changed `start_session` in `src-tauri/src/main.rs` to pass the `Window` to `start_bot`, and added `image`, `screenshots`, and `enigo` to `src-tauri/Cargo.toml`.
- Updated `stop_bot` to set the `running` flag to `false` and mark the session stopped.

### Testing
- No automated tests or CI runs were executed for this change.
- Recommend running `cargo build` for the `src-tauri` crate and project CI to validate compilation and runtime behavior on target platforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694520e378f8832589fc8022be38c5ca)