### PR TITLE
Fix Enigo mouse API usage

### DIFF
--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -1,7 +1,7 @@
 use anyhow::Result;
 use chrono::{Local, Timelike};
 use directories::ProjectDirs;
-use enigo::{Enigo, MouseButton, MouseControllable, Settings};
+use enigo::{Button, Direction, Enigo, Mouse, Settings};
 use image::RgbaImage;
 use parking_lot::RwLock;
 use serde::{Deserialize, Serialize};
@@ -369,7 +369,7 @@ pub fn start_bot(state: &SharedState, window: Window) {
                 session.clone()
             };
             emit_session_update(&window, &session_snapshot);
-            input.mouse_click(MouseButton::Left);
+            let _ = input.button(Button::Left, Direction::Click);
             thread::sleep(reel_interval);
 
             let session_snapshot = {
@@ -466,7 +466,7 @@ pub fn start_bot(state: &SharedState, window: Window) {
 
                 match capture_region(yellow_region) {
                     Ok(image) => {
-                        input.mouse_click(MouseButton::Left);
+                        let _ = input.button(Button::Left, Direction::Click);
                         let yellow_count =
                             count_matching_pixels(&image, &Color::YELLOW_CAUGHT, color_tolerance);
                         if yellow_count > 0 {


### PR DESCRIPTION
### Motivation
- The Rust build failed due to mismatched Enigo API usage: imports like `MouseButton`/`MouseControllable` and calls to `mouse_click` are not available in the vendored `enigo 0.2.1` API (errors `E0432`, `E0599`).
- Update code to use the current Enigo traits/types so input simulation compiles and uses the correct API.

### Description
- Replace `use enigo::{Enigo, MouseButton, MouseControllable, Settings};` with `use enigo::{Button, Direction, Enigo, Mouse, Settings};`.
- Replace calls to `input.mouse_click(MouseButton::Left)` with `let _ = input.button(Button::Left, Direction::Click);` in the fishing bot loop (two occurrences).
- Change uses to the `Mouse` trait methods and `Button`/`Direction` enums to match Enigo's documented API.

### Testing
- A prior build run (before the change) failed with unresolved imports and missing method errors (`E0432`, `E0599`).
- No automated tests or a full rebuild were executed on the modified code in this rollout.
- Manual inspection and compilation error output informed the change; follow-up build is recommended to verify the fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69453088fec483258f2ad05e20a6e062)