### PR TITLE
Fix always-on-top toggle: apply setting on save and at startup

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -11,11 +11,14 @@ fn get_config(state: State<'_, AppState>) -> BotConfig {
 }
 
 #[tauri::command]
-fn save_config(state: State<'_, AppState>, config: BotConfig) -> Result<(), String> {
+fn save_config(window: tauri::Window, state: State<'_, AppState>, config: BotConfig) -> Result<(), String> {
     {
         let mut stored = state.0.config.write();
         *stored = config.clone();
     }
+    window
+        .set_always_on_top(config.always_on_top)
+        .map_err(|e| e.to_string())?;
     config.save().map_err(|e| e.to_string())
 }
 
@@ -49,6 +52,13 @@ fn main() {
         .setup(|app| {
             let window = app.get_window("main").expect("main window");
             window.set_title("Arcane Fishing Bot")?;
+            let config = app
+                .state::<AppState>()
+                .0
+                .config
+                .read()
+                .always_on_top;
+            window.set_always_on_top(config)?;
             Ok(())
         })
         .run(tauri::generate_context!())


### PR DESCRIPTION
### Motivation

- Ensure the GUI's "Always on top" preference actually takes effect when the user changes it in the settings.
- Apply the stored preference on app startup so the window reflects the saved config immediately.

### Description

- Updated `src-tauri/src/main.rs`:
  - Changed the `save_config` Tauri command signature to accept a `tauri::Window` parameter and apply `window.set_always_on_top(config.always_on_top)` before saving the config.
  - During app `.setup`, read the persisted `always_on_top` value from `AppState` and call `window.set_always_on_top(...)` to honor the saved preference at startup.
- No other behavioral changes; this only ensures the Tauri window flag is updated when saving config and when the app initializes.

### Testing

- No automated tests were executed for this change.
- Change is limited to `src-tauri/src/main.rs` and affects the Tauri backend window behavior only.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694533a16f808325a15a0d2cb3bb0880)