### PR TITLE
Make `StateUpdate` cloneable and remove unused OCR/input imports

### DIFF
--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -1,10 +1,7 @@
 use anyhow::Result;
 use chrono::{Local, Timelike};
 use directories::ProjectDirs;
-use enigo::{Button, Direction, Enigo, Key, Mouse, Settings};
-use image::{DynamicImage, RgbaImage};
 use parking_lot::RwLock;
-use rusty_tesseract::{image_to_string, Args, Image};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::PathBuf;
@@ -290,7 +287,7 @@ impl SharedState {
     }
 }
 
-#[derive(Serialize)]
+#[derive(Clone, Serialize)]
 struct StateUpdate {
     stats: LifetimeStats,
     session: SessionState,


### PR DESCRIPTION
### Motivation
- Fix compilation errors observed during development: an unresolved import for `rusty_tesseract` and a trait-bound error when emitting state to the frontend via Tauri.
- The Tauri `Window::emit` API requires the payload to implement `Clone`, so `StateUpdate` must be cloneable.
- Remove unused imports that introduced an unnecessary dependency on OCR/input crates.

### Description
- Updated `src-tauri/src/backend.rs`:
  - Removed unused imports: `enigo::{...}`, `image::{...}` and `rusty_tesseract::{...}` to avoid a missing dependency error.
  - Added `#[derive(Clone, Serialize)]` to the `StateUpdate` struct so it satisfies the `Clone` bound required by `Window::emit`.
  - No other behavioral changes to the worker, state, or config logic.

### Testing
- Reproduced the original failure when running `tauri dev` (compile errors: unresolved import `rusty_tesseract` and trait bound `StateUpdate: Clone` missing).
- No automated tests were run after applying this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69453d39f5fc83259c9725182ace3a2c)