### PR TITLE
Fix Tesseract path override and update Enigo key usage in backend.rs

### DIFF
--- a/src-tauri/src/backend.rs
+++ b/src-tauri/src/backend.rs
@@ -360,11 +360,7 @@ fn check_hunger_ocr(region: Region) -> Result<u32> {
         config_variables,
     };
 
-    let result = if let Ok(mut tess_image) = TessImage::from_path(&temp_path) {
-        #[cfg(windows)]
-        {
-            tess_image.cmd = "C:\\Program Files\\Tesseract-OCR\\tesseract.exe".to_string();
-        }
+    let result = if let Ok(tess_image) = TessImage::from_path(&temp_path) {
         rusty_tesseract::image_to_string(&tess_image, &args)
             .ok()
             .and_then(|text| parse_hunger_text(&text))
@@ -569,11 +565,11 @@ fn worker_loop(state: SharedState, window: Window) {
                     emit_state_update(&window, &state);
 
                     if hunger < 50 {
-                        let _ = enigo.key(Key::Layout('1'), Direction::Click);
+                        let _ = enigo.key(Key::Unicode('1'), Direction::Click);
                         thread::sleep(Duration::from_millis(100));
                         let _ = enigo.button(Button::Left, Direction::Click);
                         thread::sleep(Duration::from_millis(200));
-                        let _ = enigo.key(Key::Layout('2'), Direction::Click);
+                        let _ = enigo.key(Key::Unicode('2'), Direction::Click);
 
                         {
                             let mut stats = state.stats.write();


### PR DESCRIPTION
### Motivation
- The project failed to compile due to incorrect usage of `rusty_tesseract` and an API change in `enigo`.
- `TessImage` does not expose a `cmd` field, so manually setting the Tesseract executable path caused `E0609`.
- `enigo::Key::Layout` no longer exists in the `enigo` version in use, causing `E0599` when feeding shortcuts were sent.
- Rely on the system `PATH` for Tesseract and use the current `enigo` key variant to restore feeding behavior.

### Description
- Removed the manual Tesseract executable override by deleting the `tess_image.cmd = "C:\\Program Files\\Tesseract-OCR\\tesseract.exe"` assignment and adjusted the `TessImage` usage to not require `mut`.
- Replaced `Key::Layout('1')` and `Key::Layout('2')` with `Key::Unicode('1')` and `Key::Unicode('2')` respectively to match the current `enigo` API.
- Changes applied to `src-tauri/src/backend.rs` (OCR path handling and feeding key presses).

### Testing
- Prior to the fix, running the app (`tauri dev`) produced compile errors: `no field 'cmd' on type Image` and `no variant 'Layout' for enigo::Key` (build failed).
- No automated tests or full rebuild were run after the fix in this patch.
- Manual validation (compile/run) is recommended: run `npm run tauri dev` or `cargo build` in `src-tauri` to confirm the errors are resolved.
- If Tesseract is not on `PATH`, ensure the system environment includes the Tesseract executable so `rusty_tesseract` can find it.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69455655b0d48325a42328585b89aeb5)