### PR TITLE
Restore settings tabs in Svelte UI

### DIFF
--- a/src/App.svelte
+++ b/src/App.svelte
@@ -19,6 +19,11 @@
   let session: SessionState | null = null;
   let status = 'Summoning arcane waters...';
   const settingsTabs = ['general', 'automation', 'regions'] as const;
+  const settingsTabLabels: Record<(typeof settingsTabs)[number], string> = {
+    general: 'General',
+    automation: 'Automation',
+    regions: 'Regions',
+  };
   let activeSettingsTab: (typeof settingsTabs)[number] = 'general';
   let configDirty = false;
   let resolutionPresets: Record<string, ResolutionPreset> = {};
@@ -356,6 +361,22 @@
         </div>
 
         {#if config}
+          <div class="flex flex-wrap gap-2 text-sm">
+            {#each settingsTabs as tab}
+              <button
+                type="button"
+                class={`px-3 py-2 border font-semibold uppercase tracking-wide rounded-none ${
+                  activeSettingsTab === tab
+                    ? 'border-orange-500 bg-orange-600 text-black'
+                    : 'border-white/20 bg-[#1d1d1d] text-white hover:bg-[#242424]'
+                }`}
+                on:click={() => (activeSettingsTab = tab)}
+              >
+                {settingsTabLabels[tab]}
+              </button>
+            {/each}
+          </div>
+
           {#if activeSettingsTab === 'general'}
             <div class="grid lg:grid-cols-[2fr_1fr] gap-4">
               <div class="space-y-4">


### PR DESCRIPTION
### Motivation
- The settings tab buttons disappeared from the Svelte UI, preventing access to configuration options like `rod_lure_value` and `fish_per_feed`.
- Reintroduce a clear tabbed control so users can switch between General, Automation, and Regions settings.

### Description
- Re-added a tab row above the settings pane in `src/App.svelte` that renders buttons for `General`, `Automation`, and `Regions`.
- Added a `settingsTabLabels` map for consistent labels and reused existing `activeSettingsTab` state to switch panes.
- Styling for active/inactive tab states was added with the same Tailwind-like classes used elsewhere in the file.
- Change is limited to UI rendering (no backend or IPC changes).

### Testing
- Started the dev server with `npm run dev` (Vite) — server started and reported ready.
- Attempted an automated Playwright screenshot to verify the tabs visually, but the Playwright run could not connect to the dev server (`ERR_CONNECTION_REFUSED`) and failed.
- No other automated tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945f3f010708325acbdfddac7ff3de6)