### PR TITLE
Migrate UI to shadcn-svelte components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,10 @@
       "name": "arcane-fishing-bot-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@tauri-apps/api": "^1.5.3"
+        "@tauri-apps/api": "^1.5.3",
+        "class-variance-authority": "^0.7.0",
+        "clsx": "^2.1.1",
+        "tailwind-merge": "^2.5.2"
       },
       "devDependencies": {
         "@sveltejs/vite-plugin-svelte": "^3.0.0",
@@ -1352,6 +1355,27 @@
         "node": ">= 6"
       }
     },
+    "node_modules/class-variance-authority": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/class-variance-authority/-/class-variance-authority-0.7.1.tgz",
+      "integrity": "sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "clsx": "^2.1.1"
+      },
+      "funding": {
+        "url": "https://polar.sh/cva"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/code-red": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/code-red/-/code-red-1.0.4.tgz",
@@ -2321,6 +2345,16 @@
       },
       "peerDependencies": {
         "svelte": "^3.19.0 || ^4.0.0"
+      }
+    },
+    "node_modules/tailwind-merge": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/tailwind-merge/-/tailwind-merge-2.6.0.tgz",
+      "integrity": "sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/dcastil"
       }
     },
     "node_modules/tailwindcss": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,10 @@
     "compile": "node scripts/compile.js"
   },
   "dependencies": {
-    "@tauri-apps/api": "^1.5.3"
+    "@tauri-apps/api": "^1.5.3",
+    "class-variance-authority": "^0.7.0",
+    "clsx": "^2.1.1",
+    "tailwind-merge": "^2.5.2"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^3.0.0",

--- a/src/app.css
+++ b/src/app.css
@@ -1,21 +1,81 @@
-@import url('https://fonts.googleapis.com/css2?family=Cinzel:wght@400;600;700&family=Inter:wght@400;500;600&display=swap');
-
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
 
-:root {
-  color-scheme: dark;
-}
+@layer base {
+  :root {
+    --background: 222.2 84% 4.9%;
+    --foreground: 210 40% 98%;
+    --card: 222.2 84% 6%;
+    --card-foreground: 210 40% 98%;
+    --popover: 222.2 84% 6%;
+    --popover-foreground: 210 40% 98%;
+    --primary: 217.2 91.2% 59.8%;
+    --primary-foreground: 222.2 47.4% 11.2%;
+    --secondary: 217.2 32.6% 17.5%;
+    --secondary-foreground: 210 40% 96%;
+    --muted: 217.2 32.6% 17.5%;
+    --muted-foreground: 215 20.2% 65.1%;
+    --accent: 217.2 32.6% 17.5%;
+    --accent-foreground: 210 40% 96%;
+    --destructive: 0 62.8% 30.6%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 217.2 32.6% 17.5%;
+    --input: 217.2 32.6% 17.5%;
+    --ring: 224.3 76.3% 48%;
+    --radius: 0.75rem;
+    color-scheme: dark;
+  }
 
-body {
-  @apply bg-obsidian text-mist font-body min-h-screen;
-}
+  .theme-pride {
+    --background: 322 48% 12%;
+    --foreground: 330 38% 96%;
+    --card: 318 44% 16%;
+    --card-foreground: 330 38% 96%;
+    --popover: 318 44% 16%;
+    --popover-foreground: 330 38% 96%;
+    --primary: 290 72% 65%;
+    --primary-foreground: 210 40% 98%;
+    --secondary: 198 70% 26%;
+    --secondary-foreground: 210 40% 98%;
+    --muted: 275 35% 24%;
+    --muted-foreground: 330 24% 70%;
+    --accent: 45 90% 55%;
+    --accent-foreground: 0 0% 10%;
+    --destructive: 0 78% 46%;
+    --destructive-foreground: 210 40% 98%;
+    --border: 320 30% 35%;
+    --input: 320 30% 35%;
+    --ring: 290 72% 65%;
+  }
 
-.glow-card {
-  @apply bg-gradient-to-br from-obsidian via-[#0f1324] to-[#0b0d16] border border-[#1f2233] shadow-[0_0_30px_rgba(124,58,237,0.15)] rounded-2xl p-6 backdrop-blur;
-}
+  .theme-black-mesa {
+    --background: 18 26% 6%;
+    --foreground: 30 20% 94%;
+    --card: 18 28% 8%;
+    --card-foreground: 30 20% 94%;
+    --popover: 18 28% 8%;
+    --popover-foreground: 30 20% 94%;
+    --primary: 28 84% 56%;
+    --primary-foreground: 18 26% 8%;
+    --secondary: 20 28% 15%;
+    --secondary-foreground: 30 20% 94%;
+    --muted: 20 24% 14%;
+    --muted-foreground: 28 18% 70%;
+    --accent: 35 70% 45%;
+    --accent-foreground: 20 20% 12%;
+    --destructive: 0 62% 30%;
+    --destructive-foreground: 30 20% 94%;
+    --border: 24 22% 22%;
+    --input: 24 22% 22%;
+    --ring: 28 84% 56%;
+  }
 
-.rune-accent {
-  @apply text-rune drop-shadow-[0_0_10px_rgba(124,58,237,0.35)];
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground font-sans antialiased;
+  }
 }

--- a/src/lib/components/ui/badge.svelte
+++ b/src/lib/components/ui/badge.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import { cva, type VariantProps } from 'class-variance-authority';
+  import { cn } from '../../utils';
+
+  const badgeVariants = cva(
+    'inline-flex items-center rounded-full border px-2.5 py-0.5 text-xs font-semibold transition-colors focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2',
+    {
+      variants: {
+        variant: {
+          default: 'border-transparent bg-primary text-primary-foreground',
+          secondary: 'border-transparent bg-secondary text-secondary-foreground',
+          outline: 'text-foreground',
+          success: 'border-emerald-500/40 bg-emerald-500/15 text-emerald-100',
+          warning: 'border-amber-500/40 bg-amber-500/15 text-amber-100',
+        },
+      },
+      defaultVariants: {
+        variant: 'default',
+      },
+    },
+  );
+
+  export let variant: VariantProps<typeof badgeVariants>['variant'] = 'default';
+  let className = '';
+  export { className as class };
+</script>
+
+<div class={cn(badgeVariants({ variant }), className)} {...$$restProps}>
+  <slot />
+</div>

--- a/src/lib/components/ui/button.svelte
+++ b/src/lib/components/ui/button.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { cva, type VariantProps } from 'class-variance-authority';
+  import { cn } from '../../utils';
+
+  const buttonVariants = cva(
+    'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 ring-offset-background',
+    {
+      variants: {
+        variant: {
+          default: 'bg-primary text-primary-foreground hover:bg-primary/90',
+          secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
+          outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
+          ghost: 'hover:bg-accent hover:text-accent-foreground',
+          destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
+        },
+        size: {
+          default: 'h-10 px-4 py-2',
+          sm: 'h-9 rounded-md px-3',
+          lg: 'h-11 rounded-md px-8',
+          icon: 'h-10 w-10',
+        },
+      },
+      defaultVariants: {
+        variant: 'default',
+        size: 'default',
+      },
+    },
+  );
+
+  export let variant: VariantProps<typeof buttonVariants>['variant'] = 'default';
+  export let size: VariantProps<typeof buttonVariants>['size'] = 'default';
+  export let type: 'button' | 'submit' | 'reset' = 'button';
+  let className = '';
+  export { className as class };
+</script>
+
+<button {type} class={cn(buttonVariants({ variant, size }), className)} {...$$restProps}>
+  <slot />
+</button>

--- a/src/lib/components/ui/card/card-content.svelte
+++ b/src/lib/components/ui/card/card-content.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { cn } from '../../../utils';
+
+  let className = '';
+  export { className as class };
+</script>
+
+<div class={cn('p-6 pt-0', className)} {...$$restProps}>
+  <slot />
+</div>

--- a/src/lib/components/ui/card/card-description.svelte
+++ b/src/lib/components/ui/card/card-description.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { cn } from '../../../utils';
+
+  let className = '';
+  export { className as class };
+</script>
+
+<p class={cn('text-sm text-muted-foreground', className)} {...$$restProps}>
+  <slot />
+</p>

--- a/src/lib/components/ui/card/card-footer.svelte
+++ b/src/lib/components/ui/card/card-footer.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { cn } from '../../../utils';
+
+  let className = '';
+  export { className as class };
+</script>
+
+<div class={cn('flex items-center p-6 pt-0', className)} {...$$restProps}>
+  <slot />
+</div>

--- a/src/lib/components/ui/card/card-header.svelte
+++ b/src/lib/components/ui/card/card-header.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { cn } from '../../../utils';
+
+  let className = '';
+  export { className as class };
+</script>
+
+<div class={cn('flex flex-col space-y-1.5 p-6', className)} {...$$restProps}>
+  <slot />
+</div>

--- a/src/lib/components/ui/card/card-title.svelte
+++ b/src/lib/components/ui/card/card-title.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { cn } from '../../../utils';
+
+  let className = '';
+  export { className as class };
+</script>
+
+<h3 class={cn('text-lg font-semibold leading-none tracking-tight', className)} {...$$restProps}>
+  <slot />
+</h3>

--- a/src/lib/components/ui/card/card.svelte
+++ b/src/lib/components/ui/card/card.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { cn } from '../../../utils';
+
+  let className = '';
+  export { className as class };
+</script>
+
+<div class={cn('rounded-lg border bg-card text-card-foreground shadow-sm', className)} {...$$restProps}>
+  <slot />
+</div>

--- a/src/lib/components/ui/card/index.ts
+++ b/src/lib/components/ui/card/index.ts
@@ -1,0 +1,6 @@
+export { default as Card } from './card.svelte';
+export { default as CardContent } from './card-content.svelte';
+export { default as CardDescription } from './card-description.svelte';
+export { default as CardFooter } from './card-footer.svelte';
+export { default as CardHeader } from './card-header.svelte';
+export { default as CardTitle } from './card-title.svelte';

--- a/src/lib/components/ui/input.svelte
+++ b/src/lib/components/ui/input.svelte
@@ -1,0 +1,39 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { cn } from '../../utils';
+
+  let className: string = '';
+  export { className as class };
+  export let type = 'text';
+  export let value: string | number | undefined;
+
+  const dispatch = createEventDispatcher();
+
+  const updateValue = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    const nextValue = type === 'number' ? target.valueAsNumber : target.value;
+    value = Number.isNaN(nextValue) ? 0 : nextValue;
+    dispatch('value', value);
+  };
+
+  const handleInput = (event: Event) => {
+    updateValue(event);
+    dispatch('input', event);
+  };
+  const handleChange = (event: Event) => {
+    updateValue(event);
+    dispatch('change', event);
+  };
+</script>
+
+<input
+  {type}
+  value={value ?? ''}
+  on:input={handleInput}
+  on:change={handleChange}
+  class={cn(
+    'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+    className,
+  )}
+  {...$$restProps}
+/>

--- a/src/lib/components/ui/label.svelte
+++ b/src/lib/components/ui/label.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { cn } from '../../utils';
+
+  let className: string = '';
+  export { className as class };
+  export let forId: string | undefined;
+</script>
+
+<label
+  for={forId}
+  class={cn('text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70', className)}
+  {...$$restProps}
+>
+  <slot />
+</label>

--- a/src/lib/components/ui/select.svelte
+++ b/src/lib/components/ui/select.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { cn } from '../../utils';
+
+  let className: string = '';
+  export { className as class };
+  export let value: string | number | undefined;
+
+  const dispatch = createEventDispatcher();
+
+  const handleChange = (event: Event) => {
+    const target = event.target as HTMLSelectElement;
+    value = target.value;
+    dispatch('value', value);
+    dispatch('change', event);
+  };
+</script>
+
+<select
+  value={value ?? ''}
+  on:change={handleChange}
+  class={cn(
+    'flex h-10 w-full rounded-md border border-input bg-background px-3 py-2 text-sm ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50',
+    className,
+  )}
+  {...$$restProps}
+>
+  <slot />
+</select>

--- a/src/lib/components/ui/switch.svelte
+++ b/src/lib/components/ui/switch.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+  import { cn } from '../../utils';
+
+  export let checked = false;
+  export let disabled = false;
+  let className: string = '';
+  export { className as class };
+  export let id: string | undefined;
+
+  const dispatch = createEventDispatcher();
+
+  const handleChange = (event: Event) => {
+    const target = event.target as HTMLInputElement;
+    checked = target.checked;
+    dispatch('checked', checked);
+    dispatch('change', event);
+  };
+</script>
+
+<label class={cn('inline-flex items-center cursor-pointer', disabled && 'cursor-not-allowed opacity-50', className)}>
+  <input
+    id={id}
+    type="checkbox"
+    bind:checked
+    disabled={disabled}
+    class="sr-only peer"
+    on:change={handleChange}
+    {...$$restProps}
+  />
+  <div
+    class="h-6 w-11 rounded-full border border-input bg-muted transition-colors peer-focus-visible:outline-none peer-focus-visible:ring-2 peer-focus-visible:ring-ring peer-focus-visible:ring-offset-2 peer-checked:bg-primary peer-checked:border-primary"
+  >
+    <div
+      class="h-5 w-5 translate-x-0.5 rounded-full bg-background shadow transition-transform duration-200 peer-checked:translate-x-5"
+    ></div>
+  </div>
+</label>

--- a/src/lib/components/ui/tabs/index.ts
+++ b/src/lib/components/ui/tabs/index.ts
@@ -1,0 +1,4 @@
+export { default as Tabs } from './tabs.svelte';
+export { default as TabsContent } from './tabs-content.svelte';
+export { default as TabsList } from './tabs-list.svelte';
+export { default as TabsTrigger } from './tabs-trigger.svelte';

--- a/src/lib/components/ui/tabs/tabs-content.svelte
+++ b/src/lib/components/ui/tabs/tabs-content.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { getContext } from 'svelte';
+  import { cn } from '../../../utils';
+  import { TABS_CONTEXT, type TabsContext } from './tabs-context';
+
+  export let value: string;
+  let className: string = '';
+  export { className as class };
+
+  const tabs = getContext<TabsContext>(TABS_CONTEXT);
+</script>
+
+{#if $tabs.value === value}
+  <div class={cn('mt-4', className)} {...$$restProps}>
+    <slot />
+  </div>
+{/if}

--- a/src/lib/components/ui/tabs/tabs-context.ts
+++ b/src/lib/components/ui/tabs/tabs-context.ts
@@ -1,0 +1,8 @@
+import type { Writable } from 'svelte/store';
+
+export const TABS_CONTEXT = Symbol('tabs');
+
+export type TabsContext = {
+  value: Writable<string>;
+  setValue: (value: string) => void;
+};

--- a/src/lib/components/ui/tabs/tabs-list.svelte
+++ b/src/lib/components/ui/tabs/tabs-list.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { cn } from '../../../utils';
+
+  let className: string = '';
+  export { className as class };
+</script>
+
+<div class={cn('inline-flex items-center rounded-md bg-muted p-1 text-muted-foreground', className)} {...$$restProps}>
+  <slot />
+</div>

--- a/src/lib/components/ui/tabs/tabs-trigger.svelte
+++ b/src/lib/components/ui/tabs/tabs-trigger.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { getContext } from 'svelte';
+  import { cn } from '../../../utils';
+  import { TABS_CONTEXT, type TabsContext } from './tabs-context';
+
+  export let value: string;
+  let className: string = '';
+  export { className as class };
+
+  const tabs = getContext<TabsContext>(TABS_CONTEXT);
+</script>
+
+<button
+  type="button"
+  on:click={() => tabs.setValue(value)}
+  class={cn(
+    'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+    className,
+  )}
+  data-state={$tabs.value === value ? 'active' : 'inactive'}
+  {...$$restProps}
+>
+  <slot />
+</button>

--- a/src/lib/components/ui/tabs/tabs.svelte
+++ b/src/lib/components/ui/tabs/tabs.svelte
@@ -1,0 +1,27 @@
+<script lang="ts">
+  import { setContext } from 'svelte';
+  import { writable } from 'svelte/store';
+  import { cn } from '../../../utils';
+  import { TABS_CONTEXT, type TabsContext } from './tabs-context';
+
+  export let value = '';
+  let className: string = '';
+  export { className as class };
+
+  const valueStore = writable(value);
+
+  const setValue = (nextValue: string) => {
+    value = nextValue;
+  };
+
+  setContext<TabsContext>(TABS_CONTEXT, {
+    value: valueStore,
+    setValue,
+  });
+
+  $: valueStore.set(value);
+</script>
+
+<div class={cn('w-full', className)} {...$$restProps}>
+  <slot />
+</div>

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from 'clsx';
+import { twMerge } from 'tailwind-merge';
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/tailwind.config.cjs
+++ b/tailwind.config.cjs
@@ -3,16 +3,57 @@ module.exports = {
   content: ['./src/**/*.{html,js,svelte,ts}'],
   darkMode: 'class',
   theme: {
+    container: {
+      center: true,
+      padding: '2rem',
+      screens: {
+        '2xl': '1400px',
+      },
+    },
     extend: {
       colors: {
-        obsidian: '#0b0d16',
-        rune: '#7c3aed',
-        ember: '#f97316',
-        mist: '#94a3b8',
+        border: 'hsl(var(--border))',
+        input: 'hsl(var(--input))',
+        ring: 'hsl(var(--ring))',
+        background: 'hsl(var(--background))',
+        foreground: 'hsl(var(--foreground))',
+        primary: {
+          DEFAULT: 'hsl(var(--primary))',
+          foreground: 'hsl(var(--primary-foreground))',
+        },
+        secondary: {
+          DEFAULT: 'hsl(var(--secondary))',
+          foreground: 'hsl(var(--secondary-foreground))',
+        },
+        destructive: {
+          DEFAULT: 'hsl(var(--destructive))',
+          foreground: 'hsl(var(--destructive-foreground))',
+        },
+        muted: {
+          DEFAULT: 'hsl(var(--muted))',
+          foreground: 'hsl(var(--muted-foreground))',
+        },
+        accent: {
+          DEFAULT: 'hsl(var(--accent))',
+          foreground: 'hsl(var(--accent-foreground))',
+        },
+        popover: {
+          DEFAULT: 'hsl(var(--popover))',
+          foreground: 'hsl(var(--popover-foreground))',
+        },
+        card: {
+          DEFAULT: 'hsl(var(--card))',
+          foreground: 'hsl(var(--card-foreground))',
+        },
+      },
+      borderRadius: {
+        lg: 'var(--radius)',
+        md: 'calc(var(--radius) - 2px)',
+        sm: 'calc(var(--radius) - 4px)',
       },
       fontFamily: {
-        display: ['"Cinzel"', 'serif'],
-        body: ['"Inter"', 'sans-serif'],
+        sans: ['Inter', 'system-ui', '-apple-system', 'BlinkMacSystemFont', 'Segoe UI', 'sans-serif'],
+        mono: ['JetBrains Mono', 'SFMono-Regular', 'Menlo', 'monospace'],
       },
     },
   },


### PR DESCRIPTION
### Motivation
- Replace the old bespoke Svelte + Tailwind UI with a small set of shadcn-style Svelte primitives to standardize styling and make the UI more composable.
- Introduce design tokens (CSS variables) and Tailwind tokens so themes/profiles can be switched cleanly.
- Provide reusable form and layout components to simplify the App markup and reduce duplicated CSS.

### Description
- Added shadcn-inspired UI primitives under `src/lib/components/ui/`: `button`, `badge`, `card/*`, `input`, `label`, `select`, `switch`, and `tabs/*`.
- Added a small utility `cn` in `src/lib/utils.ts` (uses `clsx` + `tailwind-merge`) to compose class names.
- Reworked `src/App.svelte` to use the new components and updated copy/labels to be more direct; kept Tauri integration and existing IPC usage unchanged.
- Introduced theme tokens and updated Tailwind config: `tailwind.config.cjs` now exposes `background/foreground/primary/...` color tokens; `src/app.css` defines CSS variables and theme variants.
- Updated `package.json` and `package-lock.json` to add `class-variance-authority`, `clsx`, and `tailwind-merge` and included new components in source.
- Several component implementations dispatch normalized events (`value`, `checked`, `change`) and avoid problematic dynamic bindings for Svelte inputs.

### Testing
- Installed dependencies with `npm install` — succeeded (new packages added). There were `npm audit` warnings reported but no blocking failures.
- Started the dev server with `npm run dev` — Vite reported ready (`Local: http://localhost:4173/`).
- Attempted automated screenshot capture via Playwright; navigation failed with `ERR_CONNECTION_REFUSED` when tried earlier. A `curl -I http://127.0.0.1:4173` later returned `HTTP/1.1 200 OK` (server responded). Playwright screenshot runs were unsuccessful in this environment.
- No unit tests were present or executed as part of this change.

If you want I can split components into a separate package, add docs/examples for each primitive, or run a CI build to validate the production `vite build` output.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6945f65812288325b4cd59f42d58e100)